### PR TITLE
Release/2.0.1

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -2,6 +2,9 @@ homepage: "https://snowplow.io"
 documentation: "https://docs.snowplow.io/docs/collecting-data/collecting-from-own-applications/javascript-trackers/javascript-tracker/google-tag-manager-custom-template/template-for-javascript-tracker-v3/tag-template-guide"
 versions:
   # Latest version
+  - sha: 6c1dc42ecb0ab9df763519f95782bf62215f8342
+    changeNotes: Fix handling of configuration for enableLinkClickTracking
+  # Older versions
   - sha: ef76ab0b4dd0657a122b2fb57c55ee41b9928bc1
     changeNotes: |2
       Fix missing promoFieldObject context on promoClick events (#23)
@@ -10,7 +13,6 @@ versions:
       Update Copyright to 2023 (#18)
       Fix unpkg CDN url (#17)
       Disallow trailing slash in collector hostname (#16)
-  # Older versions
   - sha: 5f1c9752e2e15fb185c5bd8242809266816e9faa
     changeNotes: |2
       Switch to snowplow.io domain (#14)

--- a/template.tpl
+++ b/template.tpl
@@ -2022,11 +2022,9 @@ switch (data.eventType) {
 
       commandName = data.linkTrackingType;
       parameters = {
-        configuration: {
-          options: filter,
-          pseudoClicks: !!data.linkTrackingPseudoClicks,
-          trackContent: !!data.linkTrackingInnerHTML,
-        },
+        options: filter,
+        pseudoClicks: !!data.linkTrackingPseudoClicks,
+        trackContent: !!data.linkTrackingInnerHTML,
       };
     } else {
       const params =

--- a/template.tpl
+++ b/template.tpl
@@ -2014,7 +2014,7 @@ switch (data.eventType) {
           data.linkTrackingAllowlist || data.linkTrackingDenylist;
         // Convert comma-separated string to an array
         filterValue =
-          filterValue && getType(filterValue) === 'string' ? filterValue.split(',').map((f) => f.trim()) : null;
+          filterValue && getType(filterValue) === 'string' ? filterValue.split(',').map((f) => f.trim()) : filterValue;
         if (filterValue)
           filter[data.linkTrackingAllowlist ? 'allowlist' : 'denylist'] =
             filterValue;

--- a/template.tpl
+++ b/template.tpl
@@ -964,7 +964,7 @@ ___TEMPLATE_PARAMETERS___
             "name": "linkTrackingAllowlist",
             "displayName": "Allowlist Classes",
             "simpleValueType": true,
-            "help": "Add a comma-separated list (or variable that returns an array) of HTML classes. If any of these classes is on the HTML element when a link click event is triggered, the event will not be tracked. NOTE! This field overrides the denylist.",
+            "help": "Add a comma-separated list (or variable that returns an array) of HTML classes. If any of these classes is not on the HTML element when a link click event is triggered, the event will not be tracked. NOTE! This option overrides the Denylist Classes below.",
             "valueHint": "class1,class2,class3"
           },
           {
@@ -973,7 +973,7 @@ ___TEMPLATE_PARAMETERS___
             "displayName": "Denylist Classes",
             "simpleValueType": true,
             "valueHint": "class1,class2,class3",
-            "help": "Add a comma-separated list of HTML classes (or variable that returns an array) . If the clicked link element has any of these classes, the link click event will be tracked. All other elements will be ignored. NOTE! Allowlist overrides this field."
+            "help": "Add a comma-separated list (or variable that returns an array) of HTML classes. If any of these classes is on the HTML element when a link click event is triggered, the event will not be tracked. NOTE! This option has no effect if Allowlist Classes is specified.",
           },
           {
             "type": "CHECKBOX",


### PR DESCRIPTION
- Fix handling of configuration for [`enableLinkClickTracking`](https://docs.snowplow.io/docs/collecting-data/collecting-from-own-applications/javascript-trackers/javascript-tracker/javascript-tracker-v3/tracking-events/#link-click-tracking)
- Allow array values for class list as described in UI documentation
- Correct link tracking allowlist/denylist documentation