### PR TITLE
Use GLOBALNAME instead of hardcoding

### DIFF
--- a/template.tpl
+++ b/template.tpl
@@ -1596,6 +1596,7 @@ const JSDELIVR =
 const SNOWPLOW_TRACKER_LIST = 'snowplow_tracker_list';
 const ERROR_LOG_PREFIX = '[ERROR GTM / Snowplow v3] ';
 const GLOBALNAME = 'snowplow'; // Note: you will need to update the 'Access global variables' template permission to reflect any changes
+const NAMESPACENAME = 'GlobalSnowplowNamespace';
 
 // Create a list of initialized trackers
 const trackerList = templateStorage.getItem(SNOWPLOW_TRACKER_LIST) || [];
@@ -1611,7 +1612,7 @@ const getSp = () => {
     return snowplow;
   }
 
-  const globalNamespace = createQueue('GlobalSnowplowNamespace');
+  const globalNamespace = createQueue(NAMESPACENAME);
   globalNamespace(GLOBALNAME);
   // Can't use createArgumentsQueue here since the Snowplow tracker library
   // does not work with GTM's wrapper

--- a/template.tpl
+++ b/template.tpl
@@ -1616,9 +1616,9 @@ const getSp = () => {
   // Can't use createArgumentsQueue here since the Snowplow tracker library
   // does not work with GTM's wrapper
   setInWindow(GLOBALNAME, function () {
-    callInWindow('snowplow.q.push', arguments);
+    callInWindow(GLOBALNAME + '.q.push', arguments);
   });
-  createQueue('snowplow.q');
+  createQueue(GLOBALNAME + '.q');
   return copyFromWindow(GLOBALNAME);
 };
 const tracker = getSp();

--- a/template.tpl
+++ b/template.tpl
@@ -1595,7 +1595,7 @@ const JSDELIVR =
   '/dist/sp.min.js';
 const SNOWPLOW_TRACKER_LIST = 'snowplow_tracker_list';
 const ERROR_LOG_PREFIX = '[ERROR GTM / Snowplow v3] ';
-const GLOBALNAME = 'snowplow';
+const GLOBALNAME = 'snowplow'; // Note: you will need to update the 'Access global variables' template permission to reflect any changes
 
 // Create a list of initialized trackers
 const trackerList = templateStorage.getItem(SNOWPLOW_TRACKER_LIST) || [];


### PR DESCRIPTION
Fix hardcoded usage of 'snowplow' global, this is technically configurable via the `GLOBALNAME` constant.

RE: Zendesk #41333